### PR TITLE
Allow PDF files with missing information

### DIFF
--- a/src/pdf_cli/commands/info.py
+++ b/src/pdf_cli/commands/info.py
@@ -21,10 +21,11 @@ pdfcli info source.pdf
 
     txt = f"""
  Filename: {input.name}
- Author: {information.author}
- Creator: {information.creator}
- Producer: {information.producer}
- Subject: {information.subject}
- Title: {information.title}
+ Author: {getattr(information, "author","")}
+ Creator: {getattr(information, "creator", "")}
+ Producer: {getattr(information, "producer", "")}
+ Subject: {getattr(information, "subject", "")}
+ Title: {getattr(information, "title", "")}
  Number of pages: {number_of_pages}"""
+ 
     print(txt)


### PR DESCRIPTION
I found a file where `pdfcli info`  fails, because the file does not have info. With this change, the command does not fail, but rather produces empty fields without errors.